### PR TITLE
Fix bug in KNN where fewer than K points returned

### DIFF
--- a/kdtree.go
+++ b/kdtree.go
@@ -83,7 +83,7 @@ func (t *KDTree) search(p *kdTreeNode,
 	for i := len(stk) - 1; i >= 0; i-- {
 		cur := stk[i]
 		dist := target.Distance(cur.splittingPoint)
-		if hp.Len() == 0 || (*hp)[0].distance >= dist {
+		if hp.Len() < k || (*hp)[0].distance >= dist {
 			heap.Push(hp, &kNNHeapNode{
 				point:    cur.splittingPoint,
 				distance: dist,


### PR DESCRIPTION
Heap was only added to when it was empty. Instead, points should always be added until heap has at least K points. Otherwise, there may be fewer than K points returned.